### PR TITLE
Move into tag-driven releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "🛠️ Build and Test"
+name: "Build and Test"
 
 # Details about the workflow:
 # - `Dockerfile` uses multi-stage builds to create build and test stages.
@@ -8,6 +8,10 @@ name: "🛠️ Build and Test"
 
 on:
   workflow_dispatch:
+
+  push:
+    branches:
+      - 'main'
 
   pull_request:
     branches: 
@@ -69,7 +73,7 @@ jobs:
         # This is useful for testing
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ github.sha }}
+          name: build-artifacts
           path: |
             build/suola-*.whl
             build/*.wasm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - name: "🔄 Checkout code"
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: "🔧 Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ on:
 
   push:
     branches:
-      - '**'
+      - 'main'
 
   pull_request:
-    branches: 
-     - '**'
+    branches:
+      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
   push:
     branches:
-      - 'main'
+      - '**'
 
   pull_request:
     branches: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ name: "🚀 Build and Upload Artifacts 🏗️"
 # - Tests are run in a containerized environment to ensure consistency. 
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - 'main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,6 @@ jobs:
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target wasm-builder -t wasm-builder .
           # Run the build entrypoint inside the container
           docker run --rm \
-            --user $(id -u):$(id -g) \
             -e GOCACHE=/tmp/gocache \
             -e HOME=/tmp \
             -v ${{ github.workspace }}/.gocache:/tmp/gocache \
@@ -66,7 +65,6 @@ jobs:
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target python-builder -t python-builder .
           # Run the build entrypoint inside the container
           docker run --rm \
-            --user $(id -u):$(id -g) \
             -e PIP_CACHE_DIR=/tmp/pipcache \
             -e HOME=/tmp \
             -v ${{ github.workspace }}/.pipcache:/tmp/pipcache \
@@ -78,7 +76,6 @@ jobs:
           mkdir -p ${{ github.workspace }}/.gocache
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target test -t test-runner .
           docker run --rm \
-            --user $(id -u):$(id -g) \
             -e GOCACHE=/tmp/gocache \
             -e HOME=/tmp \
             -v ${{ github.workspace }}/.gocache:/tmp/gocache \
@@ -90,7 +87,6 @@ jobs:
           mkdir -p ${{ github.workspace }}/.pipcache
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target python-test -t python-test-runner .
           docker run --rm \
-            --user $(id -u):$(id -g) \
             -e PIP_CACHE_DIR=/tmp/pipcache \
             -e HOME=/tmp \
             -v ${{ github.workspace }}/.pipcache:/tmp/pipcache \
@@ -100,6 +96,10 @@ jobs:
       # TODO: run test-wasi, but requires fixing the wasi tests first
       # - name: "🧪 Run WASI tests (in Docker container)"
       #   run: ...
+
+      - name: "🔧 Fix artifact and cache permissions"
+        if: always()
+        run: sudo chown -R $(id -u):$(id -g) build/ .gocache/ .pipcache/ || true
 
       - name: "⬆️ Upload artifacts"
         # Upload the build artifacts to the GitHub Actions workspace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,6 @@ jobs:
           # Run the build entrypoint inside the container
           docker run --rm \
             -e GOCACHE=/tmp/gocache \
-            -e HOME=/tmp \
             -v ${{ github.workspace }}/.gocache:/tmp/gocache \
             -v ${{ github.workspace }}/build:/app/build \
             wasm-builder
@@ -66,7 +65,6 @@ jobs:
           # Run the build entrypoint inside the container
           docker run --rm \
             -e PIP_CACHE_DIR=/tmp/pipcache \
-            -e HOME=/tmp \
             -v ${{ github.workspace }}/.pipcache:/tmp/pipcache \
             -v ${{ github.workspace }}/build:/app/build \
             python-builder
@@ -77,7 +75,6 @@ jobs:
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target test -t test-runner .
           docker run --rm \
             -e GOCACHE=/tmp/gocache \
-            -e HOME=/tmp \
             -v ${{ github.workspace }}/.gocache:/tmp/gocache \
             -v ${{ github.workspace }}/build:/app/build \
             test-runner
@@ -88,7 +85,6 @@ jobs:
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target python-test -t python-test-runner .
           docker run --rm \
             -e PIP_CACHE_DIR=/tmp/pipcache \
-            -e HOME=/tmp \
             -v ${{ github.workspace }}/.pipcache:/tmp/pipcache \
             -v ${{ github.workspace }}/build:/app/build \
             python-test-runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,38 +37,63 @@ jobs:
       - name: "🔧 Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
 
+      - name: "💾 Cache build directories"
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.gocache
+            ${{ github.workspace }}/.pipcache
+          key: ${{ runner.os }}-build-cache-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-build-cache-
 
       - name: "🏗️ Build wasm modules (in Docker container)"
         run: |
+          mkdir -p ${{ github.workspace }}/.gocache
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target wasm-builder -t wasm-builder .
           # Run the build entrypoint inside the container
           docker run --rm \
             --user $(id -u):$(id -g) \
+            -e GOCACHE=/tmp/gocache \
+            -e HOME=/tmp \
+            -v ${{ github.workspace }}/.gocache:/tmp/gocache \
             -v ${{ github.workspace }}/build:/app/build \
             wasm-builder
 
       - name: "🏗️ Build python wheel (in Docker container)"
         run: |
+          mkdir -p ${{ github.workspace }}/.pipcache
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target python-builder -t python-builder .
           # Run the build entrypoint inside the container
           docker run --rm \
             --user $(id -u):$(id -g) \
+            -e PIP_CACHE_DIR=/tmp/pipcache \
+            -e HOME=/tmp \
+            -v ${{ github.workspace }}/.pipcache:/tmp/pipcache \
             -v ${{ github.workspace }}/build:/app/build \
             python-builder
 
       - name: "🧪 Run Go tests (in Docker container)"
         run: |
+          mkdir -p ${{ github.workspace }}/.gocache
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target test -t test-runner .
           docker run --rm \
             --user $(id -u):$(id -g) \
+            -e GOCACHE=/tmp/gocache \
+            -e HOME=/tmp \
+            -v ${{ github.workspace }}/.gocache:/tmp/gocache \
             -v ${{ github.workspace }}/build:/app/build \
             test-runner
 
       - name: "🧪 Run Python tests (in Docker container)"
         run: |
+          mkdir -p ${{ github.workspace }}/.pipcache
           docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target python-test -t python-test-runner .
           docker run --rm \
             --user $(id -u):$(id -g) \
+            -e PIP_CACHE_DIR=/tmp/pipcache \
+            -e HOME=/tmp \
+            -v ${{ github.workspace }}/.pipcache:/tmp/pipcache \
             -v ${{ github.workspace }}/build:/app/build \
             python-test-runner
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           docker build --target wasm-builder -t wasm-builder .
           # Run the build entrypoint inside the container
           docker run --rm \
+            --user $(id -u):$(id -g) \
             -v ${{ github.workspace }}/build:/app/build \
             wasm-builder
 
@@ -47,6 +48,7 @@ jobs:
           docker build --target python-builder -t python-builder .
           # Run the build entrypoint inside the container
           docker run --rm \
+            --user $(id -u):$(id -g) \
             -v ${{ github.workspace }}/build:/app/build \
             python-builder
 
@@ -54,6 +56,7 @@ jobs:
         run: |
           docker build --target test -t test-runner .
           docker run --rm \
+            --user $(id -u):$(id -g) \
             -v ${{ github.workspace }}/build:/app/build \
             test-runner
 
@@ -61,6 +64,7 @@ jobs:
         run: |
           docker build --target python-test -t python-test-runner .
           docker run --rm \
+            --user $(id -u):$(id -g) \
             -v ${{ github.workspace }}/build:/app/build \
             python-test-runner
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,16 +33,16 @@ jobs:
 
     steps:
       - name: "🔄 Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: "🔧 Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: "💾 Cache build directories"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ${{ github.workspace }}/.gocache
@@ -104,7 +104,7 @@ jobs:
       - name: "⬆️ Upload artifacts"
         # Upload the build artifacts to the GitHub Actions workspace
         # This is useful for testing
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,34 +1,21 @@
-name: "🚀 Build and Upload Artifacts 🏗️"
+name: "🛠️ Build and Test"
 
 # Details about the workflow:
-# - `Dockerfile` uses multi-stage builds to create a "build", "test", and "devcontainer" stage.
+# - `Dockerfile` uses multi-stage builds to create build and test stages.
 # - Builds both browser and WASI Wasm modules and uploads them as artifacts.
 # - Builds a Python wheel from wasi build and uploads it as an artifact.
-# - Uses `svu` for automatic semantic versioning and tagging.
-# - Releases are only created on pushes to the main branch.
-# - Tests are run in a containerized environment to ensure consistency. 
+# - Runs Go and Python tests in a containerized environment.
 
 on:
   workflow_dispatch:
-
-  push:
-    branches:
-      - 'main'
 
   pull_request:
     branches: 
      - '**'
 
 permissions:
-  contents: write  # required for creating releases and uploading artifacts
+  contents: read
   actions: read  # required for uploading artifacts
-  id-token: write  # Required for attestation
-  attestations: write  # Required for attestation
-
-env:
-  # Set the default version to dev if not specified
-  version: "dev"
-  is_release: false
 
 jobs:
   build:
@@ -38,40 +25,9 @@ jobs:
     steps:
       - name: "🔄 Checkout code"
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Needed for svu to work properly
 
       - name: "🔧 Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
-
-
-      # Setup go for svu
-      # svu is used to manage semantic versioning
-      - name: "🦺 Set up Go"
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-      - name: "📦 Install svu"
-        run: go install github.com/caarlos0/svu@v1.12
-
-      - name: "🔢 Generate version"
-        run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            # Auto-bump version on main branch
-            git config --global user.name "github-actions[bot]"
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-            NEXT_VERSION=$(svu next)
-            git tag $NEXT_VERSION
-            git push origin $NEXT_VERSION
-            echo "version=$NEXT_VERSION" >> $GITHUB_ENV
-            echo "is_release=true" >> $GITHUB_ENV
-          else
-            # Use dev version for PRs
-            VERSION="$(svu current)-$(git rev-parse --short HEAD)"
-            echo "version=$VERSION" >> $GITHUB_ENV
-            echo "is_release=false" >> $GITHUB_ENV
-          fi
 
 
       - name: "🏗️ Build wasm modules (in Docker container)"
@@ -113,27 +69,8 @@ jobs:
         # This is useful for testing
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ env.version }}
+          name: build-${{ github.sha }}
           path: |
             build/suola-*.whl
             build/*.wasm
             build/wasm_exec.js
-
-      - name: "🏷️ Create GitHub Release"
-        if: env.is_release == 'true'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ env.version }}
-          files: |
-            build/suola-*.whl
-            build/*.wasm
-            build/wasm_exec.js
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "🔒 Attest release artifacts"
-        if: env.is_release == 'true'
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: 'build/*.wasm, build/wasm_exec.js, build/suola-*.whl'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "🏗️ Build wasm modules (in Docker container)"
         run: |
-          docker build --target wasm-builder -t wasm-builder .
+          docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target wasm-builder -t wasm-builder .
           # Run the build entrypoint inside the container
           docker run --rm \
             --user $(id -u):$(id -g) \
@@ -45,7 +45,7 @@ jobs:
 
       - name: "🏗️ Build python wheel (in Docker container)"
         run: |
-          docker build --target python-builder -t python-builder .
+          docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target python-builder -t python-builder .
           # Run the build entrypoint inside the container
           docker run --rm \
             --user $(id -u):$(id -g) \
@@ -54,7 +54,7 @@ jobs:
 
       - name: "🧪 Run Go tests (in Docker container)"
         run: |
-          docker build --target test -t test-runner .
+          docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target test -t test-runner .
           docker run --rm \
             --user $(id -u):$(id -g) \
             -v ${{ github.workspace }}/build:/app/build \
@@ -62,7 +62,7 @@ jobs:
 
       - name: "🧪 Run Python tests (in Docker container)"
         run: |
-          docker build --target python-test -t python-test-runner .
+          docker buildx build --load --cache-from type=gha --cache-to type=gha,mode=max --target python-test -t python-test-runner .
           docker run --rm \
             --user $(id -u):$(id -g) \
             -v ${{ github.workspace }}/build:/app/build \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ name: "Build and Test"
 
 on:
   workflow_dispatch:
+  workflow_call:
 
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ on:
     branches: 
      - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: read  # required for uploading artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,25 @@
-name: "Release"
+name: Release
 
 # Details about the workflow:
-# - Handles semantic versioning, tagging, release artifacts, and GitHub Releases.
-# - Runs only for main branch pushes or manual dispatch.
-# - Builds and tests in a containerized environment before publishing.
+# - Creates tags and GitHub Releases from artifacts produced by the build workflow.
+# - Automatically runs after successful builds on main.
+# - Supports manual release by specifying a successful build run ID.
 
 on:
   workflow_dispatch:
+    inputs:
+      build_run_id:
+        description: "Successful Build and Test workflow run ID"
+        required: true
+        type: string
 
-  push:
-    branches:
-      - 'main'
+  workflow_run:
+    workflows: ["Build and Test"]
+    types: [completed]
 
 permissions:
   contents: write  # required for creating tags and GitHub releases
-  actions: read  # required for uploading artifacts
+  actions: read  # required for downloading artifacts
   id-token: write  # required for attestation
   attestations: write  # required for attestation
 
@@ -23,17 +28,70 @@ env:
 
 jobs:
   release:
-    name: "Build, Test and Release"
+    name: "Publish Release"
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
 
     steps:
+      - name: "🔎 Resolve source run"
+        id: source
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let runId;
+            let headSha;
+            let headBranch;
+            let conclusion;
+            let workflowName;
+
+            if (context.eventName === 'workflow_dispatch') {
+              runId = Number(core.getInput('build_run_id', { required: true }));
+              const { data } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              headSha = data.head_sha;
+              headBranch = data.head_branch;
+              conclusion = data.conclusion;
+              workflowName = data.name;
+            } else {
+              runId = context.payload.workflow_run.id;
+              headSha = context.payload.workflow_run.head_sha;
+              headBranch = context.payload.workflow_run.head_branch;
+              conclusion = context.payload.workflow_run.conclusion;
+              workflowName = context.payload.workflow_run.name;
+            }
+
+            if (workflowName !== 'Build and Test') {
+              core.setFailed(`Expected source workflow 'Build and Test', got '${workflowName}'.`);
+              return;
+            }
+            if (headBranch !== 'main') {
+              core.setFailed(`Releases can only be created from main, got '${headBranch}'.`);
+              return;
+            }
+            if (conclusion !== 'success') {
+              core.setFailed(`Source build run must be successful, got '${conclusion}'.`);
+              return;
+            }
+
+            core.setOutput('run_id', String(runId));
+            core.setOutput('source_sha', headSha);
+        env:
+          INPUT_BUILD_RUN_ID: ${{ inputs.build_run_id }}
+
       - name: "🔄 Checkout code"
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Needed for svu to work properly
-
-      - name: "🔧 Set up Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+          ref: ${{ steps.source.outputs.source_sha }}
 
       - name: "🦺 Set up Go"
         uses: actions/setup-go@v5
@@ -45,55 +103,21 @@ jobs:
 
       - name: "🔢 Generate version and tag"
         run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "Releases can only be created from the main branch."
-            exit 1
-          fi
-
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
           NEXT_VERSION=$(svu next)
-          git tag $NEXT_VERSION
-          git push origin $NEXT_VERSION
-          echo "version=$NEXT_VERSION" >> $GITHUB_ENV
+          git tag "$NEXT_VERSION"
+          git push origin "$NEXT_VERSION"
+          echo "version=$NEXT_VERSION" >> "$GITHUB_ENV"
 
-      - name: "🏗️ Build wasm modules (in Docker container)"
-        run: |
-          docker build --target wasm-builder -t wasm-builder .
-          docker run --rm \
-            -v ${{ github.workspace }}/build:/app/build \
-            wasm-builder
-
-      - name: "🏗️ Build python wheel (in Docker container)"
-        run: |
-          docker build --target python-builder -t python-builder .
-          docker run --rm \
-            -v ${{ github.workspace }}/build:/app/build \
-            python-builder
-
-      - name: "🧪 Run Go tests (in Docker container)"
-        run: |
-          docker build --target test -t test-runner .
-          docker run --rm \
-            -v ${{ github.workspace }}/build:/app/build \
-            test-runner
-
-      - name: "🧪 Run Python tests (in Docker container)"
-        run: |
-          docker build --target python-test -t python-test-runner .
-          docker run --rm \
-            -v ${{ github.workspace }}/build:/app/build \
-            python-test-runner
-
-      - name: "⬆️ Upload release artifacts"
-        uses: actions/upload-artifact@v4
+      - name: "⬇️ Download build artifacts"
+        uses: actions/download-artifact@v4
         with:
-          name: release-${{ env.version }}
-          path: |
-            build/suola-*.whl
-            build/*.wasm
-            build/wasm_exec.js
+          name: build-artifacts
+          run-id: ${{ steps.source.outputs.run_id }}
+          path: build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "🏷️ Create GitHub Release"
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,4 +134,7 @@ jobs:
       - name: "🔒 Attest release artifacts"
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: 'build/*.wasm, build/wasm_exec.js, build/suola-*.whl'
+          subject-path: |
+            build/*.wasm
+            build/wasm_exec.js
+            build/suola-*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,135 +1,46 @@
 name: Release
 
 # Details about the workflow:
-# - Creates tags and GitHub Releases from artifacts produced by the build workflow.
-# - Automatically runs after successful builds on main.
-# - Supports manual release by specifying a successful build run ID.
+# - Triggers automatically when a new version tag (e.g., v1.2.3) is pushed.
+# - Calls the build workflow to produce artifacts.
+# - Creates a GitHub Release and attests the artifacts.
 
 on:
-  workflow_dispatch:
-    inputs:
-      build_run_id:
-        description: "Successful Build and Test workflow run ID"
-        required: true
-        type: string
-
-  workflow_run:
-    workflows: ["Build and Test"]
-    types: [completed]
-
-permissions:
-  contents: write  # required for creating tags and GitHub releases
-  actions: read  # required for downloading artifacts
-  id-token: write  # required for attestation
-  attestations: write  # required for attestation
-
-env:
-  version: "dev"
+  push:
+    tags:
+      - 'v*'
 
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
   release:
-    name: "Publish Release"
+    name: "🚀 Publish Release"
+    needs: build
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_branch == 'main'
-      )
+    permissions:
+      contents: write  # required for creating GitHub releases
+      id-token: write  # required for attestation
+      attestations: write  # required for attestation
 
     steps:
-      - name: "🔎 Resolve source run"
-        id: source
-        uses: actions/github-script@v7
-        with:
-          script: |
-            let runId;
-            let headSha;
-            let headBranch;
-            let conclusion;
-            let workflowName;
-
-            if (context.eventName === 'workflow_dispatch') {
-              runId = Number(core.getInput('build_run_id', { required: true }));
-              const { data } = await github.rest.actions.getWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: runId,
-              });
-              headSha = data.head_sha;
-              headBranch = data.head_branch;
-              conclusion = data.conclusion;
-              workflowName = data.name;
-            } else {
-              runId = context.payload.workflow_run.id;
-              headSha = context.payload.workflow_run.head_sha;
-              headBranch = context.payload.workflow_run.head_branch;
-              conclusion = context.payload.workflow_run.conclusion;
-              workflowName = context.payload.workflow_run.name;
-            }
-
-            if (workflowName !== 'Build and Test') {
-              core.setFailed(`Expected source workflow 'Build and Test', got '${workflowName}'.`);
-              return;
-            }
-            if (headBranch !== 'main') {
-              core.setFailed(`Releases can only be created from main, got '${headBranch}'.`);
-              return;
-            }
-            if (conclusion !== 'success') {
-              core.setFailed(`Source build run must be successful, got '${conclusion}'.`);
-              return;
-            }
-
-            core.setOutput('run_id', String(runId));
-            core.setOutput('source_sha', headSha);
-        env:
-          INPUT_BUILD_RUN_ID: ${{ inputs.build_run_id }}
-
       - name: "🔄 Checkout code"
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Needed for svu to work properly
-          ref: ${{ steps.source.outputs.source_sha }}
-
-      - name: "📦 Install svu"
-        run: |
-          curl -sLo svu.tar.gz https://github.com/caarlos0/svu/releases/download/v3.4.1/svu_3.4.1_linux_amd64.tar.gz
-          echo "7ee8c91998c15109130638dc661a912d5f426e2f8642f6f6c04e6502be920770  svu.tar.gz" | sha256sum -c -
-          tar xzf svu.tar.gz svu
-          sudo mv svu /usr/local/bin/
-          rm svu.tar.gz
-
-      - name: "🔢 Generate version and tag"
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-          NEXT_VERSION=$(svu next)
-          git tag "$NEXT_VERSION"
-          git push origin "$NEXT_VERSION"
-          echo "version=$NEXT_VERSION" >> "$GITHUB_ENV"
 
       - name: "⬇️ Download build artifacts"
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts
-          run-id: ${{ steps.source.outputs.run_id }}
           path: build
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "🏷️ Create GitHub Release"
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ env.version }}
           files: |
             build/suola-*.whl
             build/*.wasm
             build/wasm_exec.js
           generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "🔒 Attest release artifacts"
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: "🔄 Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: "⬇️ Download build artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts
           path: build
 
       - name: "🏷️ Create GitHub Release"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             build/suola-*.whl
@@ -43,7 +43,7 @@ jobs:
           generate_release_notes: true
 
       - name: "🔒 Attest release artifacts"
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             build/*.wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: "Release"
+
+# Details about the workflow:
+# - Handles semantic versioning, tagging, release artifacts, and GitHub Releases.
+# - Runs only for main branch pushes or manual dispatch.
+# - Builds and tests in a containerized environment before publishing.
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  contents: write  # required for creating tags and GitHub releases
+  actions: read  # required for uploading artifacts
+  id-token: write  # required for attestation
+  attestations: write  # required for attestation
+
+env:
+  version: "dev"
+
+jobs:
+  release:
+    name: "Build, Test and Release"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "🔄 Checkout code"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for svu to work properly
+
+      - name: "🔧 Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "🦺 Set up Go"
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: "📦 Install svu"
+        run: go install github.com/caarlos0/svu@v1.12
+
+      - name: "🔢 Generate version and tag"
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "Releases can only be created from the main branch."
+            exit 1
+          fi
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          NEXT_VERSION=$(svu next)
+          git tag $NEXT_VERSION
+          git push origin $NEXT_VERSION
+          echo "version=$NEXT_VERSION" >> $GITHUB_ENV
+
+      - name: "🏗️ Build wasm modules (in Docker container)"
+        run: |
+          docker build --target wasm-builder -t wasm-builder .
+          docker run --rm \
+            -v ${{ github.workspace }}/build:/app/build \
+            wasm-builder
+
+      - name: "🏗️ Build python wheel (in Docker container)"
+        run: |
+          docker build --target python-builder -t python-builder .
+          docker run --rm \
+            -v ${{ github.workspace }}/build:/app/build \
+            python-builder
+
+      - name: "🧪 Run Go tests (in Docker container)"
+        run: |
+          docker build --target test -t test-runner .
+          docker run --rm \
+            -v ${{ github.workspace }}/build:/app/build \
+            test-runner
+
+      - name: "🧪 Run Python tests (in Docker container)"
+        run: |
+          docker build --target python-test -t python-test-runner .
+          docker run --rm \
+            -v ${{ github.workspace }}/build:/app/build \
+            python-test-runner
+
+      - name: "⬆️ Upload release artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ env.version }}
+          path: |
+            build/suola-*.whl
+            build/*.wasm
+            build/wasm_exec.js
+
+      - name: "🏷️ Create GitHub Release"
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.version }}
+          files: |
+            build/suola-*.whl
+            build/*.wasm
+            build/wasm_exec.js
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "🔒 Attest release artifacts"
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'build/*.wasm, build/wasm_exec.js, build/suola-*.whl'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,13 +93,13 @@ jobs:
           fetch-depth: 0  # Needed for svu to work properly
           ref: ${{ steps.source.outputs.source_sha }}
 
-      - name: "🦺 Set up Go"
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-
       - name: "📦 Install svu"
-        run: go install github.com/caarlos0/svu@v1.12
+        run: |
+          curl -sLo svu.tar.gz https://github.com/caarlos0/svu/releases/download/v3.4.1/svu_3.4.1_linux_amd64.tar.gz
+          echo "7ee8c91998c15109130638dc661a912d5f426e2f8642f6f6c04e6502be920770  svu.tar.gz" | sha256sum -c -
+          tar xzf svu.tar.gz svu
+          sudo mv svu /usr/local/bin/
+          rm svu.tar.gz
 
       - name: "🔢 Generate version and tag"
         run: |

--- a/python/test/test_rules_yaml.py
+++ b/python/test/test_rules_yaml.py
@@ -40,6 +40,7 @@ def extract_test_cases():
                 'url': test.get('url'),
                 'expected': test.get('expected'),
                 'signature': test.get('sign'),
+                'xfail': test.get('xfail', False),
             })
     
     return test_cases
@@ -91,7 +92,8 @@ class TestRulesYaml:
             # Check tests structure
             for test in site['tests']:
                 assert 'url' in test
-                assert 'expected' in test
+                if not test.get('xfail', False):
+                    assert 'expected' in test
                 # signature (sign) is optional
 
     def test_all_test_cases_from_rules(self, suola, test_cases):
@@ -117,6 +119,9 @@ class TestRulesYaml:
         url = test_case['url']
         expected_sig = test_case.get('signature')
         domain = test_case['domain']
+
+        if test_case.get('xfail'):
+            pytest.xfail(f"Known unsupported rule for {domain} URL: {url}")
         
         if expected_sig:
             signature = suola(url)


### PR DESCRIPTION
- Changes build and test to run on branch pushes.
- Improved build caching.
- **Changes release to use tag-driven release, where releases are generated from tags.**
- Updates runner actions to latest -> old we're running deprecated node version.