### PR TITLE
Allow loading and appending additional rules at runtime

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -32,7 +32,7 @@ func main() {
 		fmt.Printf("Failed to load config: %v", err)
 		os.Exit(1)
 	} else {
-		fmt.Printf("Loaded config with %d sites", len(Rules.Sites))
+		fmt.Printf("Loaded config with %d sites", len(GetRules().Sites))
 	}
 
 	formattedURL, err := processURL(*urlInput)

--- a/js.go
+++ b/js.go
@@ -17,8 +17,21 @@ func hashUrl(this js.Value, args []js.Value) any {
 	return hash
 }
 
+func appendRulesJS(this js.Value, args []js.Value) any {
+	if len(args) == 0 {
+		return "rules data required"
+	}
+	rulesYaml := args[0].String()
+	err := AppendRules([]byte(rulesYaml))
+	if err != nil {
+		return err.Error()
+	}
+	return nil
+}
+
 func RegisterCallbacks() {
 	js.Global().Set("hashUrl", js.FuncOf(hashUrl))
+	js.Global().Set("appendRules", js.FuncOf(appendRulesJS))
 }
 
 func main() {

--- a/lib.go
+++ b/lib.go
@@ -11,10 +11,17 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"text/template"
 
 	"github.com/PuerkitoBio/purell"
 	"gopkg.in/yaml.v2"
+)
+
+const (
+	MaxRulesSize     = 2 * 1024 * 1024 // 2 MB
+	MaxPatternLength = 4096            // 4 KB per pattern
 )
 
 // Defines how to extract values from URL
@@ -50,7 +57,15 @@ type Config struct {
 //go:embed rules.yaml
 var DefaultCfgData []byte
 
-var Rules *Config
+var (
+	rules      atomic.Pointer[Config]
+	rulesMutex sync.Mutex
+)
+
+// GetRules returns the current active configuration snapshot.
+func GetRules() *Config {
+	return rules.Load()
+}
 
 // Calculate the effective weight of a site rule.
 // If Weight is explicitly set, it overrides automatic calculation.
@@ -81,40 +96,96 @@ func mustReadConfig(path string) []byte {
 	return data
 }
 
-// Load and compile the YAML config
-func LoadRules(data []byte) error {
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("parsing YAML: %w", err)
-	}
-
-	// Compile regex and parse templates, and compute site weights
-	for i := range cfg.Sites {
-		cfg.Sites[i]._EffectiveWeight = calculateSiteWeight(&cfg.Sites[i])
-		for j := range cfg.Sites[i].Templates {
-			tmpl, err := template.New("urlTemplate").Option("missingkey=zero").Parse(cfg.Sites[i].Templates[j].Template)
+func compileSites(sites []SiteRule) error {
+	for i := range sites {
+		sites[i]._EffectiveWeight = calculateSiteWeight(&sites[i])
+		for j := range sites[i].Templates {
+			tmpl, err := template.New("urlTemplate").Option("missingkey=zero").Parse(sites[i].Templates[j].Template)
 			if err != nil {
-				return fmt.Errorf("parsing template for domain %s: %w", cfg.Sites[i].Domain, err)
+				return fmt.Errorf("parsing template for domain %s: %w", sites[i].Domain, err)
 			}
-			cfg.Sites[i].Templates[j]._Template = tmpl
+			sites[i].Templates[j]._Template = tmpl
 
-			if cfg.Sites[i].Templates[j].Pattern != "" {
-				re, err := regexp.Compile(cfg.Sites[i].Templates[j].Pattern)
-				if err != nil {
-					return fmt.Errorf("compiling regex for domain %s: %w", cfg.Sites[i].Domain, err)
+			if sites[i].Templates[j].Pattern != "" {
+				if len(sites[i].Templates[j].Pattern) > MaxPatternLength {
+					return fmt.Errorf("regex pattern length %d exceeds maximum allowed %d for domain %s",
+						len(sites[i].Templates[j].Pattern), MaxPatternLength, sites[i].Domain)
 				}
-				cfg.Sites[i].Templates[j]._Regex = re
+				re, err := regexp.Compile(sites[i].Templates[j].Pattern)
+				if err != nil {
+					return fmt.Errorf("compiling regex for domain %s: %w", sites[i].Domain, err)
+				}
+				sites[i].Templates[j]._Regex = re
 			}
 		}
 	}
+	return nil
+}
 
-	// Sort sites descending by _EffectiveWeight (higher weight evaluated first)
-	sort.SliceStable(cfg.Sites, func(i, j int) bool {
-		return cfg.Sites[i]._EffectiveWeight > cfg.Sites[j]._EffectiveWeight
+func sortSites(sites []SiteRule) {
+	sort.SliceStable(sites, func(i, j int) bool {
+		if sites[i]._EffectiveWeight != sites[j]._EffectiveWeight {
+			return sites[i]._EffectiveWeight > sites[j]._EffectiveWeight
+		}
+		return sites[i].Domain < sites[j].Domain
 	})
+}
 
-	Rules = &cfg
+func parseAndCompile(data []byte) (*Config, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("rules data is empty")
+	}
+	if len(data) > MaxRulesSize {
+		return nil, fmt.Errorf("rules data size (%d bytes) exceeds maximum limit of %d bytes", len(data), MaxRulesSize)
+	}
 
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	if err := compileSites(cfg.Sites); err != nil {
+		return nil, err
+	}
+
+	sortSites(cfg.Sites)
+	return &cfg, nil
+}
+
+// Load and compile the YAML config, replacing any existing active rules.
+func LoadRules(data []byte) error {
+	cfg, err := parseAndCompile(data)
+	if err != nil {
+		return err
+	}
+
+	rulesMutex.Lock()
+	defer rulesMutex.Unlock()
+
+	rules.Store(cfg)
+	return nil
+}
+
+// AppendRules parses and compiles additional YAML rules, merging them with existing rules.
+func AppendRules(data []byte) error {
+	cfg, err := parseAndCompile(data)
+	if err != nil {
+		return err
+	}
+
+	rulesMutex.Lock()
+	defer rulesMutex.Unlock()
+
+	current := rules.Load()
+	merged := &Config{}
+
+	if current != nil {
+		merged.Sites = append(merged.Sites, current.Sites...)
+	}
+	merged.Sites = append(merged.Sites, cfg.Sites...)
+
+	sortSites(merged.Sites)
+	rules.Store(merged)
 	return nil
 }
 
@@ -196,7 +267,12 @@ func processURL(inputURL string) (string, error) {
 
 	host := parsed.Host
 
-	for _, site := range Rules.Sites {
+	cfg := GetRules()
+	if cfg == nil {
+		return "", fmt.Errorf("rules not loaded")
+	}
+
+	for _, site := range cfg.Sites {
 		if site.Domain == "" || host == site.Domain || strings.HasSuffix(host, "."+site.Domain) {
 			for _, rule := range site.Templates {
 				if rule._Regex == nil || rule._Regex.MatchString(parsed.Path) {

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestExtractionRules(t *testing.T) {
@@ -14,7 +17,7 @@ func TestExtractionRules(t *testing.T) {
 		t.Fatalf("Failed to load config: %v", err)
 	}
 
-	for _, site := range Rules.Sites {
+	for _, site := range GetRules().Sites {
 		for _, test := range site.Tests {
 			t.Run(fmt.Sprintf("%s/%s", site.Domain, test.Url), func(t *testing.T) {
 				var hashed = ""
@@ -162,12 +165,13 @@ sites:
 	// com -> 100 + 3 = 103
 	// "" -> 0
 	expectedDomainOrder := []string{"override.com", "www.example.com", "example.com", "com", ""}
-	if len(Rules.Sites) != len(expectedDomainOrder) {
-		t.Fatalf("Expected %d sites, got %d", len(expectedDomainOrder), len(Rules.Sites))
+	cfg := GetRules()
+	if len(cfg.Sites) != len(expectedDomainOrder) {
+		t.Fatalf("Expected %d sites, got %d", len(expectedDomainOrder), len(cfg.Sites))
 	}
 	for i, expectedDom := range expectedDomainOrder {
-		if Rules.Sites[i].Domain != expectedDom {
-			t.Errorf("Site index %d: expected domain %q, got %q", i, expectedDom, Rules.Sites[i].Domain)
+		if cfg.Sites[i].Domain != expectedDom {
+			t.Errorf("Site index %d: expected domain %q, got %q", i, expectedDom, cfg.Sites[i].Domain)
 		}
 	}
 
@@ -214,6 +218,235 @@ sites:
 			}
 		})
 	}
+}
+
+func TestRulesPayloadLimits(t *testing.T) {
+	// Empty data should fail
+	if err := LoadRules([]byte("")); err == nil {
+		t.Errorf("Expected error for empty rules data")
+	}
+
+	// Data exceeding MaxRulesSize (2MB) should fail
+	oversized := make([]byte, MaxRulesSize+1)
+	for i := range oversized {
+		oversized[i] = ' '
+	}
+	if err := LoadRules(oversized); err == nil {
+		t.Errorf("Expected error for oversized rules data")
+	}
+
+	// Oversized regex pattern should fail
+	var sb strings.Builder
+	sb.WriteString("sites:\n  - domain: limit.com\n    templates:\n      - pattern: \"")
+	for i := 0; i < MaxPatternLength+1; i++ {
+		sb.WriteString("a")
+	}
+	sb.WriteString("\"\n        template: \"https://limit.com/{{ .URL }}\"\n")
+	if err := LoadRules([]byte(sb.String())); err == nil {
+		t.Errorf("Expected error for oversized regex pattern")
+	}
+}
+
+func TestAppendRules(t *testing.T) {
+	initialYAML := []byte(`
+sites:
+  - domain: "base.com"
+    templates:
+      - pattern: "^/item/(?P<ID>[^/]+)"
+        template: "https://base.com/item/{{ .ID }}"
+`)
+
+	additionalYAML := []byte(`
+sites:
+  - domain: "appended.com"
+    templates:
+      - pattern: "^/page/(?P<ID>[^/]+)"
+        template: "https://appended.com/page/{{ .ID }}"
+`)
+
+	if err := LoadRules(initialYAML); err != nil {
+		t.Fatalf("LoadRules failed: %v", err)
+	}
+
+	res, err := processURL("https://base.com/item/1")
+	if err != nil || res != "https://base.com/item/1" {
+		t.Fatalf("Base rule failed: got %s, err %v", res, err)
+	}
+
+	if err := AppendRules(additionalYAML); err != nil {
+		t.Fatalf("AppendRules failed: %v", err)
+	}
+
+	// Verify base rule still works
+	res, err = processURL("https://base.com/item/1")
+	if err != nil || res != "https://base.com/item/1" {
+		t.Fatalf("Base rule after append failed: got %s, err %v", res, err)
+	}
+
+	// Verify appended rule works
+	res, err = processURL("https://appended.com/page/42")
+	if err != nil || res != "https://appended.com/page/42" {
+		t.Fatalf("Appended rule failed: got %s, err %v", res, err)
+	}
+}
+
+func TestDomainCollisionPriority(t *testing.T) {
+	initialYAML := []byte(`
+sites:
+  - domain: "collision.com"
+    templates:
+      - pattern: "^/article/(?P<ID>[^/]+)"
+        template: "https://collision.com/original/{{ .ID }}"
+`)
+
+	// Appending rule for collision.com with same default weight (fallback)
+	equalWeightAppendedYAML := []byte(`
+sites:
+  - domain: "collision.com"
+    templates:
+      - pattern: "^/article/(?P<ID>[^/]+)"
+        template: "https://collision.com/equal-appended/{{ .ID }}"
+      - pattern: "^/new-feature/(?P<ID>[^/]+)"
+        template: "https://collision.com/new-feature/{{ .ID }}"
+`)
+
+	if err := LoadRules(initialYAML); err != nil {
+		t.Fatalf("LoadRules failed: %v", err)
+	}
+
+	if err := AppendRules(equalWeightAppendedYAML); err != nil {
+		t.Fatalf("AppendRules failed: %v", err)
+	}
+
+	// Original rule should evaluate first for /article/
+	res, err := processURL("https://collision.com/article/100")
+	if err != nil || res != "https://collision.com/original/100" {
+		t.Fatalf("Expected original rule precedence for /article/, got %s, err %v", res, err)
+	}
+
+	// New feature path should fall through to appended rule
+	res, err = processURL("https://collision.com/new-feature/200")
+	if err != nil || res != "https://collision.com/new-feature/200" {
+		t.Fatalf("Expected fallthrough to appended rule for /new-feature/, got %s, err %v", res, err)
+	}
+
+	// Now append a high-weight override rule
+	overrideYAML := []byte(`
+sites:
+  - domain: "collision.com"
+    weight: 9999
+    templates:
+      - pattern: "^/article/(?P<ID>[^/]+)"
+        template: "https://collision.com/override/{{ .ID }}"
+`)
+
+	if err := AppendRules(overrideYAML); err != nil {
+		t.Fatalf("AppendRules override failed: %v", err)
+	}
+
+	// High-weight override rule must take top priority for /article/
+	res, err = processURL("https://collision.com/article/100")
+	if err != nil || res != "https://collision.com/override/100" {
+		t.Fatalf("Expected high-weight override rule precedence for /article/, got %s, err %v", res, err)
+	}
+}
+
+func TestAppendSortingDeterminism(t *testing.T) {
+	ruleA := `
+sites:
+  - domain: "aaa.com"
+    templates:
+      - template: "https://aaa.com{{ .Path }}"
+`
+	ruleB := `
+sites:
+  - domain: "bbb.com"
+    templates:
+      - template: "https://bbb.com{{ .Path }}"
+`
+
+	// Sequence 1: Load A, Append B
+	if err := LoadRules([]byte(ruleA)); err != nil {
+		t.Fatalf("LoadRules A failed: %v", err)
+	}
+	if err := AppendRules([]byte(ruleB)); err != nil {
+		t.Fatalf("AppendRules B failed: %v", err)
+	}
+	cfg1 := GetRules()
+	domains1 := []string{cfg1.Sites[0].Domain, cfg1.Sites[1].Domain}
+
+	// Sequence 2: Load B, Append A
+	if err := LoadRules([]byte(ruleB)); err != nil {
+		t.Fatalf("LoadRules B failed: %v", err)
+	}
+	if err := AppendRules([]byte(ruleA)); err != nil {
+		t.Fatalf("AppendRules A failed: %v", err)
+	}
+	cfg2 := GetRules()
+	domains2 := []string{cfg2.Sites[0].Domain, cfg2.Sites[1].Domain}
+
+	if domains1[0] != domains2[0] || domains1[1] != domains2[1] {
+		t.Fatalf("Sorting non-deterministic across appends: seq1 %v vs seq2 %v", domains1, domains2)
+	}
+}
+
+func TestConcurrentReadAndAppend(t *testing.T) {
+	baseYAML := []byte(`
+sites:
+  - domain: "concurrent.com"
+    templates:
+      - pattern: "^/item/(?P<ID>[^/]+)"
+        template: "https://concurrent.com/item/{{ .ID }}"
+`)
+	if err := LoadRules(baseYAML); err != nil {
+		t.Fatalf("LoadRules failed: %v", err)
+	}
+
+	stopChan := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Launch 50 reader goroutines
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stopChan:
+					return
+				default:
+					res, err := processURL("https://concurrent.com/item/99")
+					if err != nil || res != "https://concurrent.com/item/99" {
+						t.Errorf("Concurrent reader failed: got %s, err %v", res, err)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	// Launch 5 writer goroutines appending rules
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			yamlData := fmt.Sprintf(`
+sites:
+  - domain: "worker%d.com"
+    templates:
+      - pattern: "^/page/(?P<ID>[^/]+)"
+        template: "https://worker%d.com/page/{{ .ID }}"
+`, workerID, workerID)
+			for j := 0; j < 10; j++ {
+				_ = AppendRules([]byte(yamlData))
+			}
+		}(i)
+	}
+
+	// Allow writers to finish
+	time.Sleep(50 * time.Millisecond)
+	close(stopChan)
+	wg.Wait()
 }
 
 

--- a/python/src/suola/_wasm.py
+++ b/python/src/suola/_wasm.py
@@ -37,21 +37,6 @@ def get_wasi_module(pkg_name = __package__) -> Path:
         )
 
 
-class SuolaError(Exception):
-    """Base exception class for all Suola errors."""
-    pass
-
-
-class SuolaValueError(SuolaError, ValueError):
-    """Raised when URL or Rules input validation fails."""
-    pass
-
-
-class SuolaRuntimeError(SuolaError, RuntimeError):
-    """Raised when WASM allocation or execution fails."""
-    pass
-
-
 class WasmRuntime:
     """Direct WASM runtime using wasmtime-py for in-process execution."""
 
@@ -177,18 +162,30 @@ class WasmRuntime:
             self.free_fn(self.store, url_ptr)
 
     def append_rules(self, rules: str | bytes | Path) -> None:
-        """Append additional YAML rules to the runtime at runtime."""
+        """
+        Append additional YAML rules to the runtime at runtime.
+
+        Note on string resolution:
+        If a `str` is passed, it is treated as literal YAML content if it contains newlines or
+        starts with 'sites:'. Otherwise, if it corresponds to an existing file path on disk,
+        it will be read from that file. To guarantee that a file path is never misinterpreted as
+        literal YAML, pass a `pathlib.Path` instance.
+        """
         if self.append_rules_fn is None:
             raise RuntimeError("AppendRules export not available in WASM module")
 
         if isinstance(rules, Path):
             rules_bytes = rules.read_bytes()
         elif isinstance(rules, str):
-            p = Path(rules)
-            if p.exists() and p.is_file():
-                rules_bytes = p.read_bytes()
-            else:
+            s = rules.strip()
+            if "\n" in rules or s.startswith("sites:"):
                 rules_bytes = rules.encode('utf-8')
+            else:
+                p = Path(rules)
+                if p.exists() and p.is_file():
+                    rules_bytes = p.read_bytes()
+                else:
+                    rules_bytes = rules.encode('utf-8')
         elif isinstance(rules, bytes):
             rules_bytes = rules
         else:

--- a/python/src/suola/_wasm.py
+++ b/python/src/suola/_wasm.py
@@ -37,10 +37,26 @@ def get_wasi_module(pkg_name = __package__) -> Path:
         )
 
 
+class SuolaError(Exception):
+    """Base exception class for all Suola errors."""
+    pass
+
+
+class SuolaValueError(SuolaError, ValueError):
+    """Raised when URL or Rules input validation fails."""
+    pass
+
+
+class SuolaRuntimeError(SuolaError, RuntimeError):
+    """Raised when WASM allocation or execution fails."""
+    pass
+
+
 class WasmRuntime:
     """Direct WASM runtime using wasmtime-py for in-process execution."""
 
     get_signature_fn: wasmtime.Func
+    append_rules_fn: Optional[wasmtime.Func]
     malloc_fn: wasmtime.Func
     free_fn: wasmtime.Func
 
@@ -90,6 +106,7 @@ class WasmRuntime:
         logger.debug("WASM module exports: %s", [export for export in exports])
 
         self.get_signature_fn = cast(wasmtime.Func, exports["GetSignature"])
+        self.append_rules_fn = cast(Optional[wasmtime.Func], exports.get("AppendRules"))
         self.malloc_fn = cast(wasmtime.Func, exports["Malloc"])
         self.free_fn = cast(wasmtime.Func, exports["Free"])
         self.memory = cast(wasmtime.Memory, exports["memory"])
@@ -158,6 +175,54 @@ class WasmRuntime:
             # Free only the input buffer allocated by Malloc
             # Note: sig_ptr is managed by Go's memory pool and should NOT be freed here
             self.free_fn(self.store, url_ptr)
+
+    def append_rules(self, rules: str | bytes | Path) -> None:
+        """Append additional YAML rules to the runtime at runtime."""
+        if self.append_rules_fn is None:
+            raise RuntimeError("AppendRules export not available in WASM module")
+
+        if isinstance(rules, Path):
+            rules_bytes = rules.read_bytes()
+        elif isinstance(rules, str):
+            p = Path(rules)
+            if p.exists() and p.is_file():
+                rules_bytes = p.read_bytes()
+            else:
+                rules_bytes = rules.encode('utf-8')
+        elif isinstance(rules, bytes):
+            rules_bytes = rules
+        else:
+            raise TypeError(f"Invalid type for rules: {type(rules)}")
+
+        rules_len = len(rules_bytes)
+        if rules_len == 0:
+            raise ValueError("Rules data cannot be empty")
+
+        rules_ptr = self.malloc_fn(self.store, rules_len)
+        if rules_ptr == 0:
+            raise RuntimeError("Failed to allocate memory in WASM")
+
+        try:
+            memory_data = self.memory.data_ptr(self.store)
+            ptr_type = ctypes.c_ubyte * rules_len
+            src_ptr = ptr_type.from_buffer_copy(rules_bytes)
+            ctypes.memmove(ctypes.addressof(memory_data.contents) + rules_ptr, src_ptr, rules_len)
+
+            result = self.append_rules_fn(self.store, rules_ptr, rules_len)
+
+            sig_ptr = (result >> 32) & 0xFFFFFFFF
+            sig_len = result & 0x7FFFFFFF
+            is_error = (result & 0x80000000) != 0
+
+            if is_error:
+                memory_size = self.memory.data_len(self.store)
+                if sig_ptr != 0 and sig_len > 0 and sig_ptr + sig_len <= memory_size:
+                    err_msg = bytes(memory_data[sig_ptr:sig_ptr + sig_len]).decode('utf-8')
+                else:
+                    err_msg = "Unknown WASM error"
+                raise RuntimeError(f"Failed to append rules: {err_msg}")
+        finally:
+            self.free_fn(self.store, rules_ptr)
 
 
 if __name__ == "__main__":

--- a/python/src/suola/api.py
+++ b/python/src/suola/api.py
@@ -80,6 +80,12 @@ class Suola(SuolaAPI):
         Append additional YAML rules at runtime.
 
         :param rules: Path to YAML rules file, YAML string, or bytes
+
+        Note on string resolution:
+        If a `str` is passed, it is treated as literal YAML content if it contains newlines or
+        starts with 'sites:'. Otherwise, if it corresponds to an existing file path on disk,
+        it will be read from that file. To guarantee that a file path is never misinterpreted as
+        literal YAML, pass a `pathlib.Path` instance.
         """
         self._runtime.append_rules(rules)
         logger.debug("Appended additional rules")

--- a/python/src/suola/api.py
+++ b/python/src/suola/api.py
@@ -75,6 +75,15 @@ class Suola(SuolaAPI):
             logger.error(f"Error hashing URL: {e}")
         return None
 
+    def append_rules(self, rules: str | Path | bytes) -> None:
+        """
+        Append additional YAML rules at runtime.
+
+        :param rules: Path to YAML rules file, YAML string, or bytes
+        """
+        self._runtime.append_rules(rules)
+        logger.debug("Appended additional rules")
+
 if __name__ == "__main__":
     # Example usage
     logging.basicConfig(level=logging.DEBUG)

--- a/python/test/test_custom_rules.py
+++ b/python/test/test_custom_rules.py
@@ -231,4 +231,51 @@ sites:
         finally:
             rules_path.unlink()
 
+    def test_append_rules_at_runtime(self):
+        """Test appending additional rules at runtime via WasmRuntime."""
+        runtime = WasmRuntime()
+
+        # Initial rule should work for default sites
+        sig_default = runtime.get_signature("https://www.iltalehti.fi/ulkomaat/a/51495a62-a494-4474-a234-ddedae3e112b")
+        assert sig_default
+
+        # Append new rule for a new domain
+        new_rules_yaml = """
+sites:
+  - domain: "runtimeappended.org"
+    templates:
+      - pattern: "^/doc/(?P<ID>[^/]+)"
+        template: "https://runtimeappended.org/doc/{{ .ID }}"
+"""
+        runtime.append_rules(new_rules_yaml)
+
+        # Default rules still work
+        sig_default_after = runtime.get_signature("https://www.iltalehti.fi/ulkomaat/a/51495a62-a494-4474-a234-ddedae3e112b")
+        assert sig_default_after == sig_default
+
+        # Appended rule works
+        sig_appended = runtime.get_signature("https://runtimeappended.org/doc/999")
+        assert sig_appended
+        assert len(sig_appended) == 64
+
+    def test_suola_api_append_rules(self):
+        """Test appending additional rules at runtime via Suola high-level API."""
+        from suola.api import Suola
+
+        suola = Suola()
+
+        new_rules_yaml = """
+sites:
+  - domain: "highlevelapi.net"
+    templates:
+      - pattern: "^/view/(?P<ID>[^/]+)"
+        template: "https://highlevelapi.net/view/{{ .ID }}"
+"""
+        suola.append_rules(new_rules_yaml)
+
+        res = suola("https://highlevelapi.net/view/777")
+        assert res
+        assert len(res) == 64
+
+
 

--- a/wasi.go
+++ b/wasi.go
@@ -103,6 +103,30 @@ func GetSignature(urlPtr, urlLen uint32) uint64 {
 	return uint64(sigPtr)<<32 | uint64(sigLen)
 }
 
+// AppendRules parses and appends additional YAML rules at runtime.
+//
+// Parameters:
+//   - rulesPtr: Pointer to YAML string in WASM memory (allocated by caller with Malloc)
+//   - rulesLen: Length of YAML string in bytes
+//
+// Returns: uint64 packed as follows:
+//   - High 32 bits: Pointer to result string in WASM memory
+//   - Low 32 bits:  Length of result string
+//   - Bit 31 of low 32 bits: Error flag (1 = error, 0 = success)
+//
+//go:wasmexport AppendRules
+func WasmAppendRules(rulesPtr, rulesLen uint32) uint64 {
+	rulesStr := ptrToString(rulesPtr, rulesLen)
+	if err := AppendRules([]byte(rulesStr)); err != nil {
+		errMsg := err.Error()
+		errPtr, errLen := stringToPtr(errMsg)
+		return uint64(errPtr)<<32 | uint64(errLen|0x80000000)
+	}
+
+	msgPtr, msgLen := stringToPtr("OK")
+	return uint64(msgPtr)<<32 | uint64(msgLen)
+}
+
 // Helper to convert pointer and length to Go string
 func ptrToString(ptr, length uint32) string {
 	if length == 0 {


### PR DESCRIPTION
This implements the #11 .

- Refactor YAML parsing and regex/template compilation into reusable helper functions
- Add AppendRules to merge new site rules with active rules at runtime
- Replace global Rules pointer with rules atomic.Pointer[Config] and rulesMutex for lock-free snapshot reads and thread-safe atomic pointer swaps
- Enforce validation caps: MaxRulesSize (2MB) for raw YAML payloads and MaxPatternLength (4096) for regex patterns
- Implement WASM AppendRules export following packed pointer/length memory handshake standards
- Add appendRules JS callback and Python WasmRuntime.append_rules / Suola.append_rules methods
- Guarantee deterministic sorting across appends